### PR TITLE
Fixes #19: Broken composer validation.

### DIFF
--- a/src/EvaluateCommand.php
+++ b/src/EvaluateCommand.php
@@ -318,7 +318,7 @@ class EvaluateCommand
         }
         $phpcs_drupal_process = $this->startPhpCsDrupal($download_path);
         $phpcs_php_compat_process = $this->startPhpCsPhpCompat($download_path);
-        $composer_validate_process = $this->startComposerValidate();
+        $composer_validate_process = $this->startComposerValidate($download_path);
 
         // Get issue statistics.
         $this->progressBar->setMessage('Calculating issues statistics...');
@@ -542,7 +542,6 @@ class EvaluateCommand
         // @todo Throw error if download fails!
 
         $project_path = $untarred_dirpath . "/$name";
-        $this->fs->remove($project_path . '/composer.json');
 
         return $project_path;
     }
@@ -697,12 +696,15 @@ class EvaluateCommand
     /**
      * Starts the `composer validate` process.
      *
+     * @param string $download_path
+     *  The path of the directory to scan.
+     *
      * @return \Symfony\Component\Process\Process
      *   The started PHP process.
      */
-    protected function startComposerValidate(): Process
+    protected function startComposerValidate($download_path): Process
     {
-        return $this->startProcess('composer validate --strict');
+        return $this->startProcess('composer validate --strict', $download_path);
     }
 
     /**


### PR DESCRIPTION
As far as I can tell, this fixes composer validation with no adverse effects. I'm not sure why composer.json was removed in the first place, here's the relevant PR: https://github.com/grasmash/drupal-module-evaluator/pull/11