### PR TITLE
Fixes #5: Filter RTBC stats by branch.

### DIFF
--- a/src/EvaluateCommand.php
+++ b/src/EvaluateCommand.php
@@ -805,6 +805,7 @@ class EvaluateCommand
             'field_issue_status' => Statuses::RTBC,
             'sort' => 'changed',
             'direction' => 'DESC',
+            'field_issue_version' => $branch,
         ];
         $response_object = $this->requestNode($query);
         $num_rtbc = count($response_object->list);


### PR DESCRIPTION
Fixes #5 (unless you think there's additional scope to that issue)

This bug penalizes Acquia Connector a bit unfairly because it has three major branches, so it gets triple counted.